### PR TITLE
Adds iframe action helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Panoptical includes **powerful automation methods** that transform it from a bas
 - **`press_keys`** - Keyboard shortcuts and key combinations
 - **`scroll_to_element`** - Scroll to make elements visible
 - **`hover_element`** - Hover interactions with configurable duration
+- **`iframe_action`** - Perform actions inside iframes (click, type, get_text, evaluate, etc.)
 
 ## **Quick Start**
 

--- a/src/browser/action-helpers.js
+++ b/src/browser/action-helpers.js
@@ -1063,10 +1063,89 @@ export class ActionHelpers {
         await new Promise(resolve => setTimeout(resolve, duration));
       }
       
-              console.log(chalk.green(`✓ Hovered over element: `) + chalk.bold.green(`${selector}`));
+      console.log(chalk.green(`✓ Hovered over element: `) + chalk.bold.green(`${selector}`));
       return true;
     } catch (error) {
       console.error(chalk.red(`✗ Hover failed: ${error.message}`));
+      throw error;
+    }
+  }
+
+  /**
+   * iframe_action - Performs actions inside iframes (click, type, get_text, etc.)
+   */
+  async iframeAction(iframeSelector, action, targetSelector, options = {}) {
+    try {
+      const page = this.getPage();
+      
+      // Wait for iframe to be ready
+      await this.browser.waitForSelector(iframeSelector);
+      
+      // Get iframe element
+      const iframe = await page.locator(iframeSelector);
+      
+      // Wait for iframe content to load
+      await iframe.waitFor({ state: 'attached' });
+      
+      // Get iframe frame
+      const frame = iframe.contentFrame();
+      if (!frame) {
+        throw new Error(`Could not access iframe content: ${iframeSelector}`);
+      }
+      
+      // Wait for target element in iframe using Playwright's locator API
+      const targetElement = frame.locator(targetSelector);
+      await targetElement.waitFor({ timeout: options.timeout || 10000 });
+      
+      let result = null;
+      
+      // Perform the requested action
+      switch (action.toLowerCase()) {
+        case 'click':
+          await targetElement.click();
+          console.log(chalk.green(`✓ Clicked `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe `) + chalk.bold.green(`${iframeSelector}`));
+          break;
+          
+        case 'type':
+          const text = options.text || '';
+          if (!text) {
+            throw new Error('Text is required for type action');
+          }
+          await targetElement.fill(text);
+          console.log(chalk.green(`✓ Typed `) + chalk.bold.green(`"${text}"`) + chalk.green(` into `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe `) + chalk.bold.green(`${iframeSelector}`));
+          break;
+          
+        case 'get_text':
+          result = await targetElement.textContent();
+          console.log(chalk.green(`✓ Got text from `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe: `) + chalk.bold.green(`"${result}"`));
+          break;
+          
+        case 'wait':
+          await targetElement.waitFor({ timeout: options.timeout || 10000 });
+          console.log(chalk.green(`✓ Waited for `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe `) + chalk.bold.green(`${iframeSelector}`));
+          break;
+          
+        case 'is_visible':
+          result = await targetElement.isVisible();
+          console.log(chalk.green(`✓ Element `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe is `) + chalk.bold.green(result ? 'visible' : 'hidden'));
+          break;
+          
+        case 'evaluate':
+          const script = options.script || '';
+          if (!script) {
+            throw new Error('Script is required for evaluate action');
+          }
+          result = await targetElement.evaluate(script);
+          console.log(chalk.green(`✓ Executed script on `) + chalk.bold.green(`${targetSelector}`) + chalk.green(` in iframe `) + chalk.bold.green(`${iframeSelector}`));
+          break;
+          
+        default:
+          throw new Error(`Unsupported iframe action: ${action}. Use: click, type, get_text, wait, is_visible, or evaluate`);
+      }
+      
+      return result;
+    } catch (error) {
+      console.error(chalk.red(`✗ Iframe action failed: ${error.message}`));
       throw error;
     }
   }

--- a/src/browser/compatibility.js
+++ b/src/browser/compatibility.js
@@ -450,6 +450,16 @@ export class PanopticalCompatibility {
   }
 
   /**
+   * iframe_action - Performs actions inside iframes
+   */
+  async iframeAction(iframeSelector, action, targetSelector, options) {
+    if (!this.actions) {
+      throw new Error('Browser not launched. Call launch() first.');
+    }
+    return await this.actions.iframeAction(iframeSelector, action, targetSelector, options);
+  }
+
+  /**
    * Get all stored variables
    */
   getVariables() {

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -436,6 +436,12 @@ async function runSteps(browser, steps, stepType, screenshotManager, testName) {
         const { selector, duration } = step.hover_element;
         await browser.hoverElement(selector, duration);
       }
+
+      // iframe_action - Performs actions inside iframes
+      if (step.iframe_action) {
+        const { iframeSelector, action, targetSelector, options } = step.iframe_action;
+        await browser.iframeAction(iframeSelector, action, targetSelector, options);
+      }
       
     } catch (error) {
       const stepNumber = i + 1;

--- a/tests/demo-features-test.yaml
+++ b/tests/demo-features-test.yaml
@@ -225,16 +225,24 @@ steps:
       selector: "#mce_0_ifr"
       timeout: 5000
 
-  # Work with iframe content
-  - evaluate:
-      selector: "#mce_0_ifr"
-      script: |
-        const iframe = document.querySelector('#mce_0_ifr');
-        const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-        const editor = iframeDoc.querySelector('#tinymce');
-        if (editor) {
-          editor.innerHTML = 'Hello from Panoptical!';
-        }
+  # Work with iframe content using the iframe_action helper
+  - iframe_action:
+      iframeSelector: "#mce_0_ifr"
+      action: "wait"
+      targetSelector: "body"
+      timeout: 5000
+  
+  # Get the current text content from iframe
+  - iframe_action:
+      iframeSelector: "#mce_0_ifr"
+      action: "get_text"
+      targetSelector: "body"
+  
+  # Check if the iframe body is visible
+  - iframe_action:
+      iframeSelector: "#mce_0_ifr"
+      action: "is_visible"
+      targetSelector: "body"
 
   # Take final screenshot
   - snapshot: "final-state"


### PR DESCRIPTION
Introduces a new `iframe_action` helper function to simplify interactions within iframes.

This new helper allows performing actions such as clicking, typing, getting text, waiting, checking visibility, and evaluating scripts within an iframe, improving the automation capabilities. The helper method uses Playwright's locator API to target element inside the specified iframe.

Updates the README to include the new `iframe_action` helper function.

Updates the demo tests to showcase the new `iframe_action` helper.
